### PR TITLE
Updated dependencies

### DIFF
--- a/yaml-config.cabal
+++ b/yaml-config.cabal
@@ -1,5 +1,5 @@
 Name:               yaml-config
-Version:            0.2.2
+Version:            0.2.3
 Synopsis:           Configuration management
 Description:        Configuration management
 License:            MIT
@@ -18,10 +18,10 @@ Library
   Hs-source-dirs:   src
   Default-language: Haskell2010
   Ghc-options:      -Wall -fno-warn-orphans
-  Build-depends:    base                       == 4.7.* || == 4.6.* || == 4.5.*
-                  , deepseq                    == 1.3.*
+  Build-depends:    base                       == 4.8.* || == 4.7.* || == 4.6.* || == 4.5.*
+                  , deepseq                    == 1.4.* || == 1.3.*
                   , unordered-containers       == 0.2.*
-                  , text                       == 1.1.* || == 1.0.* || == 0.11.*
+                  , text                       == 1.2.* || == 1.1.* || == 1.0.* || == 0.11.*
                   , yaml                       == 0.8.*
                   , failure                    == 0.2.*
 
@@ -34,17 +34,17 @@ Test-suite howl-tests
   Default-language: Haskell2010
   Type:             exitcode-stdio-1.0
 
-  Build-depends:    base                       == 4.7.* || == 4.6.* || == 4.5.*
-                  , deepseq                    == 1.3.*
+  Build-depends:    base                       == 4.8.* || == 4.7.* || == 4.6.* || == 4.5.*
+                  , deepseq                    == 1.4.* || == 1.3.*
                   , unordered-containers       == 0.2.*
-                  , text                       == 1.1.* || == 1.0.* || == 0.11.*
+                  , text                       == 1.2.* || == 1.1.* || == 1.0.* || == 0.11.*
                   , yaml                       == 0.8.*
                   , failure                    == 0.2.*
 
                   , hashable                   == 1.2.*
-                  , tasty                      == 0.8.*
+                  , tasty                      == 0.10.*
                   , tasty-quickcheck           == 0.8.*
-                  , QuickCheck                 == 2.6.*
+                  , QuickCheck                 == 2.8.* || == 2.6.*
 
 Source-repository head
     Type:     git


### PR DESCRIPTION
Hi, I couldn't compile yaml-config on GHC 7.10 due to some of the version constraints.

After the update below, I could successfully build and run the test suite.