### PR TITLE
Moved from deprecated failure package to base Control.Exception

### DIFF
--- a/.ghci
+++ b/.ghci
@@ -1,1 +1,5 @@
 :set -isrc -pgmL markdown-unlit
+:set -package tasty
+:set -package QuickCheck
+:set -package tasty-quickcheck
+:set +c

--- a/src/Data/Yaml/Config/Internal.hs
+++ b/src/Data/Yaml/Config/Internal.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE DeriveDataTypeable #-}
-{-# LANGUAGE FlexibleContexts   #-}
-{-# LANGUAGE OverloadedStrings  #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE OverloadedStrings #-}
 
 module Data.Yaml.Config.Internal
     ( Config(..)
@@ -18,19 +18,19 @@ module Data.Yaml.Config.Internal
     , fullpath
     ) where
 
-import           Control.DeepSeq     (NFData (rnf))
-import           Control.Exception   (Exception, throw)
-import           Control.Monad       (foldM)
-import           Data.Maybe          (fromMaybe)
-import           Data.Monoid         ((<>))
-import qualified Data.Text           as ST
-import           Data.Typeable       (Typeable)
-import           Prelude             hiding (lookup)
+import Control.DeepSeq (NFData (rnf))
+import Control.Exception (Exception, throw)
+import Control.Monad (foldM)
+import Data.Maybe (fromMaybe)
+import Data.Monoid ((<>))
+import qualified Data.Text as ST
+import Data.Typeable (Typeable)
+import Prelude hiding (lookup)
 
 import qualified Data.HashMap.Strict as HashMap
-import           Data.Yaml           (FromJSON (parseJSON), Object, parseMaybe)
-import qualified Data.Yaml           as Yaml
-import qualified Data.Yaml.Include   as YamlInclude
+import Data.Yaml (FromJSON (parseJSON), Object, parseMaybe)
+import qualified Data.Yaml as Yaml
+import qualified Data.Yaml.Include as YamlInclude
 
 -- | Config or field name
 type Key = ST.Text

--- a/src/Data/Yaml/Config/Internal.hs
+++ b/src/Data/Yaml/Config/Internal.hs
@@ -28,7 +28,6 @@ import           Data.Typeable       (Typeable)
 import           Prelude             hiding (lookup)
 
 import qualified Data.HashMap.Strict as HashMap
-import Control.Failure
 import           Data.Yaml           (FromJSON (parseJSON), Object, parseMaybe)
 import qualified Data.Yaml           as Yaml
 import qualified Data.Yaml.Include   as YamlInclude
@@ -49,8 +48,8 @@ data Config = Config [Key] Object
 instance NFData Config where
     rnf (Config p o) = rnf p `seq` rnf o `seq` ()
 
-ke :: Failure KeyError m => Key -> m a
-ke = failure . KeyError
+ke :: Monad m => Key -> m a
+ke = throw . KeyError
 
 -- | Show full path from the root to target key. Levels are separated by dots.
 --
@@ -87,7 +86,7 @@ keys (Config _ o) = HashMap.keys o
 -- >>> putStrLn =<< lookup "field1" sub
 -- value1
 --
-lookup :: (Failure KeyError m, FromJSON a)
+lookup :: (Monad m, FromJSON a)
        => Key                               -- ^ Field name
        -> Config                            -- ^ Config for find
        -> m a                               -- ^ Field value
@@ -120,7 +119,7 @@ lookupDefault p d = fromMaybe d . lookup p
 -- >>> :set -XOverloadedStrings
 -- >>> sub <- subconfig "section1" config
 --
-subconfig :: Failure KeyError m
+subconfig :: Monad m
           => Key                 -- ^ Subconfig name
           -> Config              -- ^ (Sub)Config for find
           -> m Config            -- ^ Founded Subconfig

--- a/src/Data/Yaml/Config/Internal.hs
+++ b/src/Data/Yaml/Config/Internal.hs
@@ -1,7 +1,6 @@
-{-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE DeriveDataTypeable #-}
-{-# LANGUAGE FlexibleContexts #-}
-{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE FlexibleContexts   #-}
+{-# LANGUAGE OverloadedStrings  #-}
 
 module Data.Yaml.Config.Internal
     ( Config(..)
@@ -19,20 +18,20 @@ module Data.Yaml.Config.Internal
     , fullpath
     ) where
 
-import Prelude hiding (lookup)
-import Control.DeepSeq (NFData(rnf))
-import Control.Exception (Exception)
-import Control.Monad (foldM)
-import Data.Maybe (fromMaybe)
-import Data.Monoid ((<>))
-import Data.Typeable (Typeable)
-import qualified Data.Text as ST
+import           Control.DeepSeq     (NFData (rnf))
+import           Control.Exception   (Exception, throw)
+import           Control.Monad       (foldM)
+import           Data.Maybe          (fromMaybe)
+import           Data.Monoid         ((<>))
+import qualified Data.Text           as ST
+import           Data.Typeable       (Typeable)
+import           Prelude             hiding (lookup)
 
-import Data.Yaml (Object, FromJSON(parseJSON), parseMaybe)
 import qualified Data.HashMap.Strict as HashMap
-import qualified Data.Yaml as Yaml
-import qualified Data.Yaml.Include as YamlInclude
 import Control.Failure
+import           Data.Yaml           (FromJSON (parseJSON), Object, parseMaybe)
+import qualified Data.Yaml           as Yaml
+import qualified Data.Yaml.Include   as YamlInclude
 
 -- | Config or field name
 type Key = ST.Text

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,6 +1,5 @@
 resolver: lts-5.0
 flags: {}
+extra-deps: []
 packages:
   - .
-extra-deps:
-  - failure-0.2.0.3

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,0 +1,6 @@
+resolver: lts-5.0
+flags: {}
+packages:
+  - .
+extra-deps:
+  - failure-0.2.0.3

--- a/tests/Tests.hs
+++ b/tests/Tests.hs
@@ -2,21 +2,19 @@
 
 module Main where
 
-import           Control.Monad             (liftM)
-import           Data.List                 as List
-import           Data.Monoid               ((<>))
-import           Data.Text                 as Text
+import Control.Monad (liftM)
+import Data.List as List
+import Data.Monoid ((<>))
+import Data.Text as Text
 
-import qualified Data.HashMap.Strict       as HashMap
-import           Data.Yaml                 (Object, Value (Object))
-import           Test.QuickCheck           (Arbitrary (..), Gen, expectFailure,
-                                            sized)
-import           Test.QuickCheck.Monadic   (monadicIO, run)
-import           Test.Tasty                (defaultMain, testGroup)
-import           Test.Tasty.QuickCheck     (Property, testProperty)
+import qualified Data.HashMap.Strict as HashMap
+import Data.Yaml (Object, Value (Object))
+import Test.QuickCheck (Arbitrary (..), Gen, expectFailure, sized)
+import Test.QuickCheck.Monadic (monadicIO, run)
+import Test.Tasty (defaultMain, testGroup)
+import Test.Tasty.QuickCheck (Property, testProperty)
 
-import           Data.Yaml.Config.Internal (Config (Config), Key, fullpath,
-                                            keys, subconfig)
+import Data.Yaml.Config.Internal (Config (Config), Key, fullpath, keys, subconfig)
 
 type CorrectPath = [Key]
 

--- a/tests/Tests.hs
+++ b/tests/Tests.hs
@@ -2,24 +2,19 @@
 
 module Main where
 
-import Control.Monad (liftM)
-import Data.Monoid ((<>))
-import Data.Hashable (Hashable)
-import Data.Text (Text)
-import Data.List as List
-import Data.Text as Text
-import qualified Data.Text as ST
+import           Control.Monad             (liftM)
+import           Data.List                 as List
+import           Data.Monoid               ((<>))
+import           Data.Text                 as Text
 
-import Test.Tasty (defaultMain, testGroup)
-import Test.Tasty.QuickCheck (testProperty)
-import Test.QuickCheck (Gen, Property, Arbitrary(..), elements, sized, oneof,
-                        listOf)
-import Test.QuickCheck.Monadic (assert)
-import Data.Yaml(Object, Value(Object, Null))
-import qualified Data.HashMap.Strict as HashMap
+import qualified Data.HashMap.Strict       as HashMap
+import           Data.Yaml                 (Object, Value (Object))
+import           Test.QuickCheck           (Arbitrary (..), Gen, sized)
+import           Test.Tasty                (defaultMain, testGroup)
+import           Test.Tasty.QuickCheck     (testProperty)
 
-import Data.Yaml.Config.Internal (Config(Config), Key, subconfig, keys,
-                                  fullpath)
+import           Data.Yaml.Config.Internal (Config (Config), Key, fullpath,
+                                            keys, subconfig)
 
 type CorrectPath = [Key]
 
@@ -35,22 +30,22 @@ newObject :: [(Key, Value)] -> Object
 newObject = HashMap.fromList
 
 deepConfig :: Gen DeepObject
-deepConfig = sized deepConfig' >>= \(keys, obj) ->
-    return $ DeepObject (Config [] obj) $ List.tail keys
+deepConfig = sized deepConfig' >>= \(ks, obj) ->
+    return $ DeepObject (Config [] obj) $ List.tail ks
 
 deepConfig' :: Int -> Gen ([Key], Object)
-deepConfig' 0 = arbitrary >>= \newKey -> return $ ([newKey], newObject [])
+deepConfig' 0 = arbitrary >>= \newKey -> return ([newKey], newObject [])
 deepConfig' n | n > 0 = do
     newKey <- arbitrary
-    (keys, newNode) <- deepConfig' (pred n)
-    return $ (newKey : keys, newObject [(List.head keys , Object newNode)])
+    (ks, newNode) <- deepConfig' (pred n)
+    return (newKey : ks, newObject [(List.head ks , Object newNode)])
 
 testCorrectSubconfigPath :: DeepObject -> Bool
 testCorrectSubconfigPath (DeepObject _ []) = True
 testCorrectSubconfigPath (DeepObject config (key : others)) =
     maybe False (`subcheck` others) $ subconfig key config
   where
-    subcheck sc keys = testCorrectSubconfigPath $ DeepObject sc keys
+    subcheck sc = testCorrectSubconfigPath . DeepObject sc
 
 testWrongSubconfigPath :: DeepObject -> Bool
 testWrongSubconfigPath (DeepObject config []) = List.null $ keys config
@@ -64,13 +59,14 @@ testWrongSubconfigPath (DeepObject config (nextKey : others)) =
 
 testCorrectPath :: DeepObject -> Bool
 testCorrectPath = testCorrectPath' []
-testCorrectPath' path (DeepObject config (nextKey : others)) = checkPath config
-    && (maybe False (`subcheck` others) $ subconfig nextKey config)
   where
-    subcheck sc keys = testCorrectPath' (nextKey : path) $ DeepObject sc keys
-    checkPath c = fullpath c nextKey ==
-                  (ST.intercalate "." $ List.reverse $ nextKey : path)
-testCorrectPath' _ (DeepObject config []) = List.null $ keys config
+    testCorrectPath' path (DeepObject config (nextKey : others)) = checkPath config
+        && maybe False (`subcheck` others) (subconfig nextKey config)
+      where
+        subcheck sc = testCorrectPath' (nextKey : path) . DeepObject sc
+        checkPath c = fullpath c nextKey ==
+            Text.intercalate "." (List.reverse $ nextKey : path)
+    testCorrectPath' _ (DeepObject config []) = List.null $ keys config
 
 main :: IO ()
 main = defaultMain $ testGroup "Tests"

--- a/yaml-config.cabal
+++ b/yaml-config.cabal
@@ -20,8 +20,8 @@ Library
   Ghc-options:      -Wall -fno-warn-orphans
   Build-depends:    base                       >= 4.5.0 && < 5.0.0
                   , deepseq                    >= 1.3
-                  , unordered-containers       >= 0.2.0
                   , text                       >= 0.11.0
+                  , unordered-containers       >= 0.2.0
                   , yaml                       >= 0.8.10
                   , failure                    >= 0.2.0
 
@@ -34,17 +34,16 @@ Test-suite yaml-config-tests
   Default-language: Haskell2010
   Type:             exitcode-stdio-1.0
 
-  Build-depends:    base                       >= 4.5.0 && < 5.0.0
+  Build-depends:    QuickCheck                 >= 2.6.0
+                  , base                       >= 4.5.0 && < 5.0.0
                   , deepseq                    >= 1.3
-                  , unordered-containers       >= 0.2.0
-                  , text                       >= 0.11.0
-                  , yaml                       >= 0.8.10
                   , failure                    >= 0.2.0
-
                   , hashable                   >= 1.2.0
                   , tasty                      >= 0.10.0
                   , tasty-quickcheck           >= 0.8.0
-                  , QuickCheck                 >= 2.6.0
+                  , text                       >= 0.11.0
+                  , unordered-containers       >= 0.2.0
+                  , yaml                       >= 0.8.10
 
 Source-repository head
     Type:     git

--- a/yaml-config.cabal
+++ b/yaml-config.cabal
@@ -23,7 +23,6 @@ Library
                   , text                       >= 0.11.0
                   , unordered-containers       >= 0.2.0
                   , yaml                       >= 0.8.10
-                  , failure                    >= 0.2.0
 
   Exposed-modules:  Data.Yaml.Config
                     Data.Yaml.Config.Internal
@@ -37,7 +36,6 @@ Test-suite yaml-config-tests
   Build-depends:    QuickCheck                 >= 2.6.0
                   , base                       >= 4.5.0 && < 5.0.0
                   , deepseq                    >= 1.3
-                  , failure                    >= 0.2.0
                   , hashable                   >= 1.2.0
                   , tasty                      >= 0.10.0
                   , tasty-quickcheck           >= 0.8.0


### PR DESCRIPTION
The [`failure`](https://hackage.haskell.org/package/failure) package is deprecated so I moved to [`base#Control.Exception`](https://hackage.haskell.org/package/base/docs/Control-Exception.html) to remove dependencies. Fixes #11. Fixed a lot of `hlint` and `stylish-haskell` suggestions as well.